### PR TITLE
[data streams] Add primary tag

### DIFF
--- a/datastreams/aggregator.go
+++ b/datastreams/aggregator.go
@@ -184,6 +184,7 @@ func (a *aggregator) reportStats() {
 		a.statsd.Count("datadog.datastreams.aggregator.flushed_payloads", atomic.SwapInt64(&a.stats.flushedPayloads, 0), nil, 1)
 		a.statsd.Count("datadog.datastreams.aggregator.flushed_buckets", atomic.SwapInt64(&a.stats.flushedBuckets, 0), nil, 1)
 		a.statsd.Count("datadog.datastreams.aggregator.flush_errors", atomic.SwapInt64(&a.stats.flushErrors, 0), nil, 1)
+		a.statsd.Count("datadog.datastreams.dropped_payloads", atomic.SwapInt64(&a.stats.dropped, 0), nil, 1)
 	}
 }
 

--- a/datastreams/aggregator_test.go
+++ b/datastreams/aggregator_test.go
@@ -26,7 +26,7 @@ func buildSketch(values ...float64) []byte {
 }
 
 func TestAggregator(t *testing.T) {
-	p := newAggregator(nil, "env", "service", "agent-addr", nil, "datadoghq.com", "key", true)
+	p := newAggregator(nil, "env", "datacenter:us1.prod.dog", "service", "agent-addr", nil, "datadoghq.com", "key", true)
 	tp1 := time.Now()
 	tp2 := tp1.Add(time.Second * 40)
 	p.add(statsPoint{
@@ -63,8 +63,9 @@ func TestAggregator(t *testing.T) {
 	})
 	// flush at tp2 doesn't flush tp2 (current bucket)
 	assert.Equal(t, StatsPayload{
-		Env:     "env",
-		Service: "service",
+		Env:        "env",
+		Service:    "service",
+		PrimaryTag: "datacenter:us1.prod.dog",
 		Stats: []StatsBucket{{
 			Start:    uint64(alignTs(tp1.UnixNano(), bucketDuration.Nanoseconds())),
 			Duration: uint64(bucketDuration.Nanoseconds()),
@@ -82,8 +83,9 @@ func TestAggregator(t *testing.T) {
 		return sp.Stats[0].Stats[i].Hash < sp.Stats[0].Stats[j].Hash
 	})
 	assert.Equal(t, StatsPayload{
-		Env:     "env",
-		Service: "service",
+		Env:        "env",
+		Service:    "service",
+		PrimaryTag: "datacenter:us1.prod.dog",
 		Stats: []StatsBucket{{
 			Start:    uint64(alignTs(tp2.UnixNano(), bucketDuration.Nanoseconds())),
 			Duration: uint64(bucketDuration.Nanoseconds()),

--- a/datastreams/init.go
+++ b/datastreams/init.go
@@ -37,7 +37,7 @@ func Start(opts ...StartOption) {
 		log.Print("ERROR: Agent does not support pipeline stats and pipeline stats aggregator launched in agent mode.")
 		return
 	}
-	p := newAggregator(cfg.statsd, cfg.env, cfg.service, cfg.agentAddr, cfg.httpClient, cfg.site, cfg.apiKey, cfg.agentLess)
+	p := newAggregator(cfg.statsd, cfg.env, cfg.primaryTag, cfg.service, cfg.agentAddr, cfg.httpClient, cfg.site, cfg.apiKey, cfg.agentLess)
 	p.Start()
 	setGlobalAggregator(p)
 }

--- a/datastreams/options.go
+++ b/datastreams/options.go
@@ -46,6 +46,8 @@ type config struct {
 	service string
 	// env contains the environment that this application will run under.
 	env string
+	// primaryTag contains the primary tag that this application will run under
+	primaryTag string
 	// agentAddr specifies the hostname and port of the agent where the traces
 	// are sent to.
 	agentAddr string
@@ -82,6 +84,9 @@ func newConfig(opts ...StartOption) *config {
 	}
 	if v := os.Getenv("DD_SERVICE"); v != "" {
 		c.service = v
+	}
+	if v := os.Getenv("DD_PRIMARY_TAG"); v != "" {
+		c.primaryTag = v
 	}
 	for _, fn := range opts {
 		fn(c)

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -14,8 +14,10 @@ import (
 
 func TestPathway(t *testing.T) {
 	aggregator := aggregator{
-		in:      make(chan statsPoint, 10),
-		service: "service-1",
+		in:         make(chan statsPoint, 10),
+		service:    "service-1",
+		env:        "env",
+		primaryTag: "d:1",
 	}
 	setGlobalAggregator(&aggregator)
 	defer setGlobalAggregator(nil)
@@ -25,15 +27,13 @@ func TestPathway(t *testing.T) {
 	p := newPathway(start)
 	p = p.setCheckpoint(middle, []string{"edge-1"})
 	p = p.setCheckpoint(end, []string{"edge-2"})
-	hash1 := pathwayHash(nodeHash("service-1", nil), 0)
-	hash2 := pathwayHash(nodeHash("service-1", []string{"edge-1"}), hash1)
-	hash3 := pathwayHash(nodeHash("service-1", []string{"edge-2"}), hash2)
+	hash1 := pathwayHash(nodeHash("service-1", "env", "d:1", nil), 0)
+	hash2 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"edge-1"}), hash1)
+	hash3 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"edge-2"}), hash2)
 	assert.Equal(t, Pathway{
 		hash:         hash3,
 		pathwayStart: start,
 		edgeStart:    end,
-		service:      "service-1",
-		edgeTags:     []string{"edge-2"},
 	}, p)
 	assert.Equal(t, statsPoint{
 		edgeTags:       nil,

--- a/datastreams/payload.go
+++ b/datastreams/payload.go
@@ -13,6 +13,8 @@ type StatsPayload struct {
 	Env string
 	// Service is the service of the application
 	Service string
+	// PrimaryTag is the primary tag of the application.
+	PrimaryTag string
 	// Stats holds all stats buckets computed within this payload.
 	Stats []StatsBucket
 }

--- a/datastreams/propagator.go
+++ b/datastreams/propagator.go
@@ -44,6 +44,5 @@ func Decode(data []byte) (p Pathway, err error) {
 	}
 	p.pathwayStart = time.Unix(0, pathwayStart*int64(time.Millisecond))
 	p.edgeStart = time.Unix(0, edgeStart*int64(time.Millisecond))
-	p.service = getService()
 	return p, nil
 }

--- a/datastreams/propagator_test.go
+++ b/datastreams/propagator_test.go
@@ -14,19 +14,12 @@ import (
 
 func TestEncode(t *testing.T) {
 	now := time.Now().Local().Truncate(time.Millisecond)
-	aggregator := aggregator{
-		service: "service-1",
-	}
-	setGlobalAggregator(&aggregator)
-	defer setGlobalAggregator(nil)
-
 	p := Pathway{
 		hash:         234,
 		pathwayStart: now.Add(-time.Hour),
 		edgeStart:    now,
 	}
 	encoded := p.Encode()
-	p.service = "service-1"
 	decoded, err := Decode(encoded)
 	assert.Nil(t, err)
 	assert.Equal(t, p, decoded)


### PR DESCRIPTION
Users can set the primary tag as an env variable. If they do, we use it inside the node hash computation.
We also use the env inside the node hash computation.
That way, we can monitor cross env / cross primary tag traffic.