### PR TITLE
datastreams: Use DD_AGENT_HOST

### DIFF
--- a/datastreams/init.go
+++ b/datastreams/init.go
@@ -21,7 +21,11 @@ var (
 func setGlobalAggregator(a *aggregator) {
 	mu.Lock()
 	defer mu.Unlock()
+	old := activeAggregator
 	activeAggregator = a
+	if old != nil {
+		old.Stop()
+	}
 }
 
 func getGlobalAggregator() *aggregator {

--- a/datastreams/options.go
+++ b/datastreams/options.go
@@ -77,7 +77,7 @@ type StartOption func(*config)
 // and passed user opts.
 func newConfig(opts ...StartOption) *config {
 	c := new(config)
-	c.agentAddr = defaultAddress
+	c.agentAddr = getAgentAddr()
 	c.httpClient = defaultHTTPClient()
 	if v := os.Getenv("DD_ENV"); v != "" {
 		c.env = v
@@ -139,6 +139,19 @@ func newConfig(opts ...StartOption) *config {
 		}
 	}
 	return c
+}
+
+// getAgentAddr returns the agent address.
+func getAgentAddr() string {
+	host := defaultHostname
+	port := defaultPort
+	if v := os.Getenv("DD_AGENT_HOST"); v != "" {
+		host = v
+	}
+	if v := os.Getenv("DD_TRACE_AGENT_PORT"); v != "" {
+		port = v
+	}
+	return fmt.Sprintf("%s:%s", host, port)
 }
 
 // defaultHTTPClient returns the default http.Client to start the tracer with.

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestPathway(t *testing.T) {
 	aggregator := aggregator{
+		stopped:    1,
 		in:         make(chan statsPoint, 10),
 		service:    "service-1",
 		env:        "env",

--- a/datastreams/transport.go
+++ b/datastreams/transport.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -67,37 +66,13 @@ func newHTTPTransport(addr string, site string, apiKey string, client *http.Clie
 		defaultHeaders["DD-API-KEY"] = apiKey
 		url = fmt.Sprintf("https://trace.agent.%s/api/v0.1/pipeline_stats", site)
 	} else {
-		url = fmt.Sprintf("http://%s/v0.1/pipeline_stats", resolveAddr(addr))
+		url = fmt.Sprintf("http://%s/v0.1/pipeline_stats", addr)
 	}
 	return &httpTransport{
 		url:     url,
 		client:  client,
 		headers: defaultHeaders,
 	}
-}
-
-// resolveAddr resolves the given agent address and fills in any missing host
-// and port using the defaults. Some environment variable settings will
-// take precedence over configuration.
-func resolveAddr(addr string) string {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		// no port in addr
-		host = addr
-	}
-	if host == "" {
-		host = defaultHostname
-	}
-	if port == "" {
-		port = defaultPort
-	}
-	if v := os.Getenv("DD_AGENT_HOST"); v != "" {
-		host = v
-	}
-	if v := os.Getenv("DD_TRACE_AGENT_PORT"); v != "" {
-		port = v
-	}
-	return fmt.Sprintf("%s:%s", host, port)
 }
 
 func (t *httpTransport) sendPipelineStats(p *StatsPayload) error {

--- a/datastreams/transport_test.go
+++ b/datastreams/transport_test.go
@@ -73,7 +73,7 @@ func TestHTTPTransport(t *testing.T) {
 
 	t.Run("with_agent", func(t *testing.T) {
 		fakeTransport := fakeTransport{}
-		transport := newHTTPTransport("agent-address", "datadoghq.com", "key", &http.Client{Transport: &fakeTransport}, false)
+		transport := newHTTPTransport("agent-address:8126", "datadoghq.com", "key", &http.Client{Transport: &fakeTransport}, false)
 		assert.Nil(t, transport.sendPipelineStats(&p))
 		assert.Len(t, fakeTransport.requests, 1)
 		r := fakeTransport.requests[0]


### PR DESCRIPTION
1. The env variable DD_AGENT_HOST can override the agent address.
2. If you call Start more than one time, it will have the effect of restarting the aggregator (vs starting multiple aggregators)