### PR TITLE
datastreams: add tracer version & tracer lang tags

### DIFF
--- a/datastreams/aggregator.go
+++ b/datastreams/aggregator.go
@@ -235,6 +235,5 @@ func (a *aggregator) sendToAgent(payload StatsPayload) {
 	atomic.AddInt64(&a.stats.flushedBuckets, int64(len(payload.Stats)))
 	if err := a.transport.sendPipelineStats(&payload); err != nil {
 		atomic.AddInt64(&a.stats.flushErrors, 1)
-		log.Printf("WARN: Error sending data streams stats payload: %v", err)
 	}
 }

--- a/datastreams/aggregator.go
+++ b/datastreams/aggregator.go
@@ -18,6 +18,8 @@ import (
 	"github.com/DataDog/sketches-go/ddsketch/mapping"
 	"github.com/DataDog/sketches-go/ddsketch/store"
 	"github.com/golang/protobuf/proto"
+
+	"github.com/DataDog/data-streams-go/datastreams/version"
 )
 
 const (
@@ -211,10 +213,12 @@ func (a *aggregator) flushBucket(bucketStart int64) StatsBucket {
 func (a *aggregator) flush(now time.Time) StatsPayload {
 	nowNano := now.UnixNano()
 	sp := StatsPayload{
-		Service:    a.service,
-		Env:        a.env,
-		PrimaryTag: a.primaryTag,
-		Stats:      make([]StatsBucket, 0, len(a.buckets)),
+		Service:       a.service,
+		Env:           a.env,
+		PrimaryTag:    a.primaryTag,
+		Lang:          "go",
+		TracerVersion: version.Tag,
+		Stats:         make([]StatsBucket, 0, len(a.buckets)),
 	}
 	for ts := range a.buckets {
 		if ts > nowNano-bucketDuration.Nanoseconds() {

--- a/datastreams/payload.go
+++ b/datastreams/payload.go
@@ -17,13 +17,17 @@ type StatsPayload struct {
 	PrimaryTag string
 	// Stats holds all stats buckets computed within this payload.
 	Stats []StatsBucket
+	// TracerVersion is the version of the tracer
+	TracerVersion string
+	// Lang is the language of the tracer
+	Lang string
 }
 
 // StatsBucket specifies a set of stats computed over a duration.
 type StatsBucket struct {
-	// Start specifies the beginning of this bucket.
+	// Start specifies the beginning of this bucket in unix nanoseconds.
 	Start uint64
-	// Duration specifies the duration of this bucket.
+	// Duration specifies the duration of this bucket in nanoseconds.
 	Duration uint64
 	// Stats contains a set of statistics computed for the duration of this bucket.
 	Stats []StatsPoint
@@ -37,6 +41,7 @@ type StatsPoint struct {
 	Hash       uint64
 	ParentHash uint64
 	// These fields specify the stats for the above aggregation.
+	// those are distributions of latency in seconds.
 	PathwayLatency []byte
 	EdgeLatency    []byte
 }

--- a/datastreams/payload_msgp.go
+++ b/datastreams/payload_msgp.go
@@ -173,6 +173,18 @@ func (z *StatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
+		case "TracerVersion":
+			z.TracerVersion, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "TracerVersion")
+				return
+			}
+		case "Lang":
+			z.Lang, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Lang")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -186,9 +198,9 @@ func (z *StatsPayload) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *StatsPayload) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
+	// map header, size 6
 	// write "Env"
-	err = en.Append(0x84, 0xa3, 0x45, 0x6e, 0x76)
+	err = en.Append(0x86, 0xa3, 0x45, 0x6e, 0x76)
 	if err != nil {
 		return
 	}
@@ -234,6 +246,26 @@ func (z *StatsPayload) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	}
+	// write "TracerVersion"
+	err = en.Append(0xad, 0x54, 0x72, 0x61, 0x63, 0x65, 0x72, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.TracerVersion)
+	if err != nil {
+		err = msgp.WrapError(err, "TracerVersion")
+		return
+	}
+	// write "Lang"
+	err = en.Append(0xa4, 0x4c, 0x61, 0x6e, 0x67)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Lang)
+	if err != nil {
+		err = msgp.WrapError(err, "Lang")
+		return
+	}
 	return
 }
 
@@ -243,6 +275,7 @@ func (z *StatsPayload) Msgsize() (s int) {
 	for za0001 := range z.Stats {
 		s += z.Stats[za0001].Msgsize()
 	}
+	s += 14 + msgp.StringPrefixSize + len(z.TracerVersion) + 5 + msgp.StringPrefixSize + len(z.Lang)
 	return
 }
 

--- a/datastreams/version/version.go
+++ b/datastreams/version/version.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package version
+
+// Tag specifies the current release tag. It needs to be manually
+// updated. A test checks that the value of Tag never points to a
+// git tag that is older than HEAD.
+const Tag = "v0.2"

--- a/datastreams/version/version_test.go
+++ b/datastreams/version/version_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package version
+
+import (
+	"bytes"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTag(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		// git probably not installed; don't fail the test suite
+		t.Skip(err)
+	}
+	out, err := exec.Command("git", "show", "-s", "--format=%ct", "HEAD", Tag).CombinedOutput()
+	if err != nil {
+		if bytes.Contains(out, []byte("unknown revision")) {
+			// test passed: the tag was not found
+			return
+		}
+		t.Skip(err)
+	}
+	dates := strings.Split(string(bytes.TrimSpace(out)), "\n")
+	if len(dates) != 2 {
+		t.Skip("unexpected output: ", dates)
+	}
+	dateHEAD, err := unixDate(dates[0])
+	if err != nil {
+		t.Skip(err)
+	}
+	dateTag, err := unixDate(dates[1])
+	if err != nil {
+		t.Skip(err)
+	}
+	if dateTag.Before(dateHEAD) {
+		t.Fatalf(
+			"\n(internal/version).Tag value needs to be updated!\n• %s was already released %s\n• Latest commit (HEAD) dates %s",
+			Tag,
+			dateTag.Format(time.Stamp),
+			dateHEAD.Format(time.Stamp),
+		)
+	}
+}
+
+func unixDate(u string) (time.Time, error) {
+	sec, err := strconv.ParseInt(u, 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(sec, 0), nil
+}


### PR DESCRIPTION
Add tracer lang, and tracer version to payload, so that we can debug issues more easily in the future.