### PR TITLE
Modify SetCheckpoint() to always propagate edgeTags regardless of whether the context already has a pathway

### DIFF
--- a/datastreams/context.go
+++ b/datastreams/context.go
@@ -38,10 +38,11 @@ func SetCheckpoint(ctx context.Context, edgeTags ...string) (Pathway, context.Co
 		ctx = context.Background()
 	}
 	p, ok := PathwayFromContext(ctx)
-	if !ok {
-		p = NewPathway()
+	if ok {
+		p = p.SetCheckpoint(edgeTags...)
+	} else {
+		p = NewPathway(edgeTags...)
 	}
-	p = p.SetCheckpoint(edgeTags...)
 	ctx = ContextWithPathway(ctx, p)
 	return p, ctx
 }

--- a/datastreams/context.go
+++ b/datastreams/context.go
@@ -38,12 +38,10 @@ func SetCheckpoint(ctx context.Context, edgeTags ...string) (Pathway, context.Co
 		ctx = context.Background()
 	}
 	p, ok := PathwayFromContext(ctx)
-	if ok {
-		p = p.SetCheckpoint(edgeTags...)
-	} else {
-		// skip the edge if there is nothing before this node.
+	if !ok {
 		p = NewPathway()
 	}
+	p = p.SetCheckpoint(edgeTags...)
 	ctx = ContextWithPathway(ctx, p)
 	return p, ctx
 }

--- a/datastreams/context_test.go
+++ b/datastreams/context_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datastreams
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContext(t *testing.T) {
+	t.Run("SetCheckpoint", func(t *testing.T) {
+		aggregator := aggregator{
+			stopped:    1,
+			in:         make(chan statsPoint, 10),
+			service:    "service-1",
+			env:        "env",
+			primaryTag: "d:1",
+		}
+		setGlobalAggregator(&aggregator)
+		defer setGlobalAggregator(nil)
+		start := time.Now()
+		hash1 := pathwayHash(nodeHash("service-1", "env", "d:1", nil), 0)
+		hash2 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"type:internal"}), hash1)
+
+		ctx := context.Background()
+		pathway := newPathway(start)
+
+		ctx = ContextWithPathway(ctx, pathway)
+		updatedPathway, _ := SetCheckpoint(ctx, "type:internal")
+
+		statsPt1 := <-aggregator.in
+		statsPt2 := <-aggregator.in
+
+		assert.Equal(t, []string(nil), statsPt1.edgeTags)
+		assert.Equal(t, hash1, statsPt1.hash)
+		assert.Equal(t, uint64(0), statsPt1.parentHash)
+		assert.Equal(t, start.UnixNano(), statsPt1.timestamp)
+
+		assert.Equal(t, []string{"type:internal"}, statsPt2.edgeTags)
+		assert.Equal(t, hash2, statsPt2.hash)
+		assert.Equal(t, hash1, statsPt2.parentHash)
+
+		assert.Equal(t, statsPt2.hash, updatedPathway.hash)
+	})
+}

--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -90,7 +90,6 @@ func (p Pathway) SetCheckpoint(edgeTags ...string) Pathway {
 }
 
 func (p Pathway) setCheckpoint(now time.Time, edgeTags []string) Pathway {
-
 	aggr := getGlobalAggregator()
 	service := defaultServiceName
 	primaryTag := ""

--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -71,17 +71,17 @@ func pathwayHash(nodeHash, parentHash uint64) uint64 {
 }
 
 // NewPathway creates a new pathway.
-func NewPathway() Pathway {
-	return newPathway(time.Now())
+func NewPathway(edgeTags ...string) Pathway {
+	return newPathway(time.Now(), edgeTags...)
 }
 
-func newPathway(now time.Time) Pathway {
+func newPathway(now time.Time, edgeTags ...string) Pathway {
 	p := Pathway{
 		hash:         0,
 		pathwayStart: now,
 		edgeStart:    now,
 	}
-	return p.setCheckpoint(now, nil)
+	return p.setCheckpoint(now, edgeTags)
 }
 
 // SetCheckpoint sets a checkpoint on a pathway.
@@ -90,6 +90,7 @@ func (p Pathway) SetCheckpoint(edgeTags ...string) Pathway {
 }
 
 func (p Pathway) setCheckpoint(now time.Time, edgeTags []string) Pathway {
+
 	aggr := getGlobalAggregator()
 	service := defaultServiceName
 	primaryTag := ""

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -13,51 +13,86 @@ import (
 )
 
 func TestPathway(t *testing.T) {
-	aggregator := aggregator{
-		stopped:    1,
-		in:         make(chan statsPoint, 10),
-		service:    "service-1",
-		env:        "env",
-		primaryTag: "d:1",
-	}
-	setGlobalAggregator(&aggregator)
-	defer setGlobalAggregator(nil)
-	start := time.Now()
-	middle := start.Add(time.Hour)
-	end := middle.Add(time.Hour)
-	p := newPathway(start)
-	p = p.setCheckpoint(middle, []string{"edge-1"})
-	p = p.setCheckpoint(end, []string{"edge-2"})
-	hash1 := pathwayHash(nodeHash("service-1", "env", "d:1", nil), 0)
-	hash2 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"edge-1"}), hash1)
-	hash3 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"edge-2"}), hash2)
-	assert.Equal(t, Pathway{
-		hash:         hash3,
-		pathwayStart: start,
-		edgeStart:    end,
-	}, p)
-	assert.Equal(t, statsPoint{
-		edgeTags:       nil,
-		hash:           hash1,
-		parentHash:     0,
-		timestamp:      start.UnixNano(),
-		pathwayLatency: 0,
-		edgeLatency:    0,
-	}, <-aggregator.in)
-	assert.Equal(t, statsPoint{
-		edgeTags:       []string{"edge-1"},
-		hash:           hash2,
-		parentHash:     hash1,
-		timestamp:      middle.UnixNano(),
-		pathwayLatency: middle.Sub(start).Nanoseconds(),
-		edgeLatency:    middle.Sub(start).Nanoseconds(),
-	}, <-aggregator.in)
-	assert.Equal(t, statsPoint{
-		edgeTags:       []string{"edge-2"},
-		hash:           hash3,
-		parentHash:     hash2,
-		timestamp:      end.UnixNano(),
-		pathwayLatency: end.Sub(start).Nanoseconds(),
-		edgeLatency:    end.Sub(middle).Nanoseconds(),
-	}, <-aggregator.in)
+	t.Run("test SetCheckPoint", func(t *testing.T) {
+		aggregator := aggregator{
+			stopped:    1,
+			in:         make(chan statsPoint, 10),
+			service:    "service-1",
+			env:        "env",
+			primaryTag: "d:1",
+		}
+		setGlobalAggregator(&aggregator)
+		defer setGlobalAggregator(nil)
+		start := time.Now()
+		middle := start.Add(time.Hour)
+		end := middle.Add(time.Hour)
+		p := newPathway(start)
+		p = p.setCheckpoint(middle, []string{"edge-1"})
+		p = p.setCheckpoint(end, []string{"edge-2"})
+		hash1 := pathwayHash(nodeHash("service-1", "env", "d:1", nil), 0)
+		hash2 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"edge-1"}), hash1)
+		hash3 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"edge-2"}), hash2)
+		assert.Equal(t, Pathway{
+			hash:         hash3,
+			pathwayStart: start,
+			edgeStart:    end,
+		}, p)
+		assert.Equal(t, statsPoint{
+			edgeTags:       nil,
+			hash:           hash1,
+			parentHash:     0,
+			timestamp:      start.UnixNano(),
+			pathwayLatency: 0,
+			edgeLatency:    0,
+		}, <-aggregator.in)
+		assert.Equal(t, statsPoint{
+			edgeTags:       []string{"edge-1"},
+			hash:           hash2,
+			parentHash:     hash1,
+			timestamp:      middle.UnixNano(),
+			pathwayLatency: middle.Sub(start).Nanoseconds(),
+			edgeLatency:    middle.Sub(start).Nanoseconds(),
+		}, <-aggregator.in)
+		assert.Equal(t, statsPoint{
+			edgeTags:       []string{"edge-2"},
+			hash:           hash3,
+			parentHash:     hash2,
+			timestamp:      end.UnixNano(),
+			pathwayLatency: end.Sub(start).Nanoseconds(),
+			edgeLatency:    end.Sub(middle).Nanoseconds(),
+		}, <-aggregator.in)
+	})
+
+	t.Run("test NewPathway", func(t *testing.T) {
+		aggregator := aggregator{
+			stopped:    1,
+			in:         make(chan statsPoint, 10),
+			service:    "service-1",
+			env:        "env",
+			primaryTag: "d:1",
+		}
+		setGlobalAggregator(&aggregator)
+		defer setGlobalAggregator(nil)
+
+		pathwayWithNoEdgeTags := NewPathway()
+		pathwayWith1EdgeTag := NewPathway("type:internal")
+		pathwayWith2EdgeTags := NewPathway("type:internal", "some_other_key:some_other_val")
+
+		hash1 := pathwayHash(nodeHash("service-1", "env", "d:1", nil), 0)
+		hash2 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"type:internal"}), 0)
+		hash3 := pathwayHash(nodeHash("service-1", "env", "d:1", []string{"type:internal", "some_other_key:some_other_val"}), 0)
+		assert.Equal(t, hash1, pathwayWithNoEdgeTags.hash)
+		assert.Equal(t, hash2, pathwayWith1EdgeTag.hash)
+		assert.Equal(t, hash3, pathwayWith2EdgeTags.hash)
+
+		var statsPointWithNoEdgeTags statsPoint = <-aggregator.in
+		var statsPointWith1EdgeTag statsPoint = <-aggregator.in
+		var statsPointWith2EdgeTags statsPoint = <-aggregator.in
+		assert.Equal(t, hash1, statsPointWithNoEdgeTags.hash)
+		assert.Equal(t, []string(nil), statsPointWithNoEdgeTags.edgeTags)
+		assert.Equal(t, hash2, statsPointWith1EdgeTag.hash)
+		assert.Equal(t, []string{"type:internal"}, statsPointWith1EdgeTag.edgeTags)
+		assert.Equal(t, hash3, statsPointWith2EdgeTags.hash)
+		assert.Equal(t, []string{"some_other_key:some_other_val", "type:internal"}, statsPointWith2EdgeTags.edgeTags)
+	})
 }


### PR DESCRIPTION
Currently SetCheckpoint does not propagate edgeTags when the ctx doesn't have an existing pathway. It will just create a new pathway without tags.

This change will create a new pathway if one doesn't already exist in the ctx, and it will always call SetCheckpoint on the pathway, such that edgeTags will be propagated.