### PR TITLE
[DSM] Add a new timestampType field to StatsPoint

### DIFF
--- a/datastreams/aggregator.go
+++ b/datastreams/aggregator.go
@@ -49,7 +49,7 @@ type statsGroup struct {
 
 type bucket map[uint64]statsGroup
 
-func (b bucket) export() []StatsPoint {
+func (b bucket) export(timestampType string) []StatsPoint {
 	stats := make([]StatsPoint, 0, len(b))
 	for _, s := range b {
 		pathwayLatency, err := proto.Marshal(s.pathwayLatency.ToProto())
@@ -69,6 +69,7 @@ func (b bucket) export() []StatsPoint {
 			EdgeTags:       s.edgeTags,
 			Hash:           s.hash,
 			ParentHash:     s.parentHash,
+			TimestampType:  timestampType,
 		})
 	}
 	return stats
@@ -83,29 +84,31 @@ type aggregatorStats struct {
 }
 
 type aggregator struct {
-	in         chan statsPoint
-	buckets    map[int64]bucket
-	wg         sync.WaitGroup
-	stopped    uint64
-	stop       chan struct{} // closing this channel triggers shutdown
-	stats      aggregatorStats
-	transport  *httpTransport
-	statsd     statsd.ClientInterface
-	env        string
-	primaryTag string
-	service    string
+	in                   chan statsPoint
+	tsTypeCurrentBuckets map[int64]bucket
+	tsTypeOriginBuckets  map[int64]bucket
+	wg                   sync.WaitGroup
+	stopped              uint64
+	stop                 chan struct{} // closing this channel triggers shutdown
+	stats                aggregatorStats
+	transport            *httpTransport
+	statsd               statsd.ClientInterface
+	env                  string
+	primaryTag           string
+	service              string
 }
 
 func newAggregator(statsd statsd.ClientInterface, env, primaryTag, service, agentAddr string, httpClient *http.Client, site, apiKey string, agentLess bool) *aggregator {
 	return &aggregator{
-		buckets:    make(map[int64]bucket),
-		in:         make(chan statsPoint, 10000),
-		stopped:    1,
-		statsd:     statsd,
-		env:        env,
-		primaryTag: primaryTag,
-		service:    service,
-		transport:  newHTTPTransport(agentAddr, site, apiKey, httpClient, agentLess),
+		tsTypeCurrentBuckets: make(map[int64]bucket),
+		tsTypeOriginBuckets:  make(map[int64]bucket),
+		in:                   make(chan statsPoint, 10000),
+		stopped:              1,
+		statsd:               statsd,
+		env:                  env,
+		primaryTag:           primaryTag,
+		service:              service,
+		transport:            newHTTPTransport(agentAddr, site, apiKey, httpClient, agentLess),
 	}
 }
 
@@ -113,12 +116,11 @@ func newAggregator(statsd statsd.ClientInterface, env, primaryTag, service, agen
 // It gives us the start time of the time bucket in which such timestamp falls.
 func alignTs(ts, bucketSize int64) int64 { return ts - ts%bucketSize }
 
-func (a *aggregator) add(point statsPoint) {
-	btime := alignTs(point.timestamp, bucketDuration.Nanoseconds())
-	b, ok := a.buckets[btime]
+func (a *aggregator) addToBuckets(point statsPoint, btime int64, buckets map[int64]bucket) {
+	b, ok := buckets[btime]
 	if !ok {
 		b = make(bucket)
-		a.buckets[btime] = b
+		buckets[btime] = b
 	}
 	group, ok := b[point.hash]
 	if !ok {
@@ -137,6 +139,14 @@ func (a *aggregator) add(point statsPoint) {
 	if err := group.edgeLatency.Add(math.Max(float64(point.edgeLatency)/float64(time.Second), 0)); err != nil {
 		log.Printf("ERROR: failed to add edge latency. Ignoring %v.", err)
 	}
+}
+
+func (a *aggregator) add(point statsPoint) {
+	currentBucketTime := alignTs(point.timestamp, bucketDuration.Nanoseconds())
+	a.addToBuckets(point, currentBucketTime, a.tsTypeCurrentBuckets)
+	originTimestamp := point.timestamp - point.pathwayLatency
+	originBucketTime := alignTs(originTimestamp, bucketDuration.Nanoseconds())
+	a.addToBuckets(point, originBucketTime, a.tsTypeOriginBuckets)
 }
 
 func (a *aggregator) run(tick <-chan time.Time) {
@@ -200,13 +210,13 @@ func (a *aggregator) runFlusher() {
 	}
 }
 
-func (a *aggregator) flushBucket(bucketStart int64) StatsBucket {
-	bucket := a.buckets[bucketStart]
-	delete(a.buckets, bucketStart)
+func (a *aggregator) flushBucket(buckets map[int64]bucket, bucketStart int64, timestampType string) StatsBucket {
+	bucket := buckets[bucketStart]
+	delete(buckets, bucketStart)
 	return StatsBucket{
 		Start:    uint64(bucketStart),
 		Duration: uint64(bucketDuration.Nanoseconds()),
-		Stats:    bucket.export(),
+		Stats:    bucket.export(timestampType),
 	}
 }
 
@@ -218,14 +228,21 @@ func (a *aggregator) flush(now time.Time) StatsPayload {
 		PrimaryTag:    a.primaryTag,
 		Lang:          "go",
 		TracerVersion: version.Tag,
-		Stats:         make([]StatsBucket, 0, len(a.buckets)),
+		Stats:         make([]StatsBucket, 0, len(a.tsTypeCurrentBuckets)+len(a.tsTypeOriginBuckets)),
 	}
-	for ts := range a.buckets {
+	for ts := range a.tsTypeCurrentBuckets {
 		if ts > nowNano-bucketDuration.Nanoseconds() {
-			// do not flush the current bucket
+			// do not flush the bucket at the current time
 			continue
 		}
-		sp.Stats = append(sp.Stats, a.flushBucket(ts))
+		sp.Stats = append(sp.Stats, a.flushBucket(a.tsTypeCurrentBuckets, ts, "current"))
+	}
+	for ts := range a.tsTypeOriginBuckets {
+		if ts > nowNano-bucketDuration.Nanoseconds() {
+			// do not flush the bucket at the current time
+			continue
+		}
+		sp.Stats = append(sp.Stats, a.flushBucket(a.tsTypeOriginBuckets, ts, "origin"))
 	}
 	return sp
 }

--- a/datastreams/aggregator.go
+++ b/datastreams/aggregator.go
@@ -49,7 +49,7 @@ type statsGroup struct {
 
 type bucket map[uint64]statsGroup
 
-func (b bucket) export(timestampType string) []StatsPoint {
+func (b bucket) export(timestampType TimestampType) []StatsPoint {
 	stats := make([]StatsPoint, 0, len(b))
 	for _, s := range b {
 		pathwayLatency, err := proto.Marshal(s.pathwayLatency.ToProto())
@@ -210,7 +210,7 @@ func (a *aggregator) runFlusher() {
 	}
 }
 
-func (a *aggregator) flushBucket(buckets map[int64]bucket, bucketStart int64, timestampType string) StatsBucket {
+func (a *aggregator) flushBucket(buckets map[int64]bucket, bucketStart int64, timestampType TimestampType) StatsBucket {
 	bucket := buckets[bucketStart]
 	delete(buckets, bucketStart)
 	return StatsBucket{
@@ -235,14 +235,14 @@ func (a *aggregator) flush(now time.Time) StatsPayload {
 			// do not flush the bucket at the current time
 			continue
 		}
-		sp.Stats = append(sp.Stats, a.flushBucket(a.tsTypeCurrentBuckets, ts, "current"))
+		sp.Stats = append(sp.Stats, a.flushBucket(a.tsTypeCurrentBuckets, ts, TIMESTAMP_TYPE_CURRENT))
 	}
 	for ts := range a.tsTypeOriginBuckets {
 		if ts > nowNano-bucketDuration.Nanoseconds() {
 			// do not flush the bucket at the current time
 			continue
 		}
-		sp.Stats = append(sp.Stats, a.flushBucket(a.tsTypeOriginBuckets, ts, "origin"))
+		sp.Stats = append(sp.Stats, a.flushBucket(a.tsTypeOriginBuckets, ts, TIMESTAMP_TYPE_ORIGIN))
 	}
 	return sp
 }

--- a/datastreams/payload.go
+++ b/datastreams/payload.go
@@ -44,4 +44,5 @@ type StatsPoint struct {
 	// those are distributions of latency in seconds.
 	PathwayLatency []byte
 	EdgeLatency    []byte
+	TimestampType  string
 }

--- a/datastreams/payload.go
+++ b/datastreams/payload.go
@@ -33,6 +33,13 @@ type StatsBucket struct {
 	Stats []StatsPoint
 }
 
+type TimestampType string
+
+const (
+	TIMESTAMP_TYPE_CURRENT TimestampType = "current"
+	TIMESTAMP_TYPE_ORIGIN  TimestampType = "origin"
+)
+
 // StatsPoint contains a set of statistics grouped under various aggregation keys.
 type StatsPoint struct {
 	// These fields indicate the properties under which the stats were aggregated.
@@ -44,5 +51,5 @@ type StatsPoint struct {
 	// those are distributions of latency in seconds.
 	PathwayLatency []byte
 	EdgeLatency    []byte
-	TimestampType  string
+	TimestampType  TimestampType
 }

--- a/datastreams/payload_msgp.go
+++ b/datastreams/payload_msgp.go
@@ -347,10 +347,14 @@ func (z *StatsPoint) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "TimestampType":
-			z.TimestampType, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "TimestampType")
-				return
+			{
+				var zb0003 string
+				zb0003, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "TimestampType")
+					return
+				}
+				z.TimestampType = TimestampType(zb0003)
 			}
 		default:
 			err = dc.Skip()
@@ -438,7 +442,7 @@ func (z *StatsPoint) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteString(z.TimestampType)
+	err = en.WriteString(string(z.TimestampType))
 	if err != nil {
 		err = msgp.WrapError(err, "TimestampType")
 		return
@@ -452,6 +456,36 @@ func (z *StatsPoint) Msgsize() (s int) {
 	for za0001 := range z.EdgeTags {
 		s += msgp.StringPrefixSize + len(z.EdgeTags[za0001])
 	}
-	s += 5 + msgp.Uint64Size + 11 + msgp.Uint64Size + 15 + msgp.BytesPrefixSize + len(z.PathwayLatency) + 12 + msgp.BytesPrefixSize + len(z.EdgeLatency) + 14 + msgp.StringPrefixSize + len(z.TimestampType)
+	s += 5 + msgp.Uint64Size + 11 + msgp.Uint64Size + 15 + msgp.BytesPrefixSize + len(z.PathwayLatency) + 12 + msgp.BytesPrefixSize + len(z.EdgeLatency) + 14 + msgp.StringPrefixSize + len(string(z.TimestampType))
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TimestampType) DecodeMsg(dc *msgp.Reader) (err error) {
+	{
+		var zb0001 string
+		zb0001, err = dc.ReadString()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		(*z) = TimestampType(zb0001)
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z TimestampType) EncodeMsg(en *msgp.Writer) (err error) {
+	err = en.WriteString(string(z))
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z TimestampType) Msgsize() (s int) {
+	s = msgp.StringPrefixSize + len(string(z))
 	return
 }

--- a/datastreams/payload_msgp.go
+++ b/datastreams/payload_msgp.go
@@ -346,6 +346,12 @@ func (z *StatsPoint) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "EdgeLatency")
 				return
 			}
+		case "TimestampType":
+			z.TimestampType, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "TimestampType")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -359,9 +365,9 @@ func (z *StatsPoint) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *StatsPoint) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 6
+	// map header, size 7
 	// write "Service"
-	err = en.Append(0x86, 0xa7, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65)
+	err = en.Append(0x87, 0xa7, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65)
 	if err != nil {
 		return
 	}
@@ -427,6 +433,16 @@ func (z *StatsPoint) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "EdgeLatency")
 		return
 	}
+	// write "TimestampType"
+	err = en.Append(0xad, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x54, 0x79, 0x70, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.TimestampType)
+	if err != nil {
+		err = msgp.WrapError(err, "TimestampType")
+		return
+	}
 	return
 }
 
@@ -436,6 +452,6 @@ func (z *StatsPoint) Msgsize() (s int) {
 	for za0001 := range z.EdgeTags {
 		s += msgp.StringPrefixSize + len(z.EdgeTags[za0001])
 	}
-	s += 5 + msgp.Uint64Size + 11 + msgp.Uint64Size + 15 + msgp.BytesPrefixSize + len(z.PathwayLatency) + 12 + msgp.BytesPrefixSize + len(z.EdgeLatency)
+	s += 5 + msgp.Uint64Size + 11 + msgp.Uint64Size + 15 + msgp.BytesPrefixSize + len(z.PathwayLatency) + 12 + msgp.BytesPrefixSize + len(z.EdgeLatency) + 14 + msgp.StringPrefixSize + len(z.TimestampType)
 	return
 }


### PR DESCRIPTION
Add a new timestampType field to StatsPoint, allowing us to send points with timestamps that are either based on current time or origin time. To be used in new availability metric to help us quickly detect offline consumers.