### PR TITLE
Add new timestamp type to StatsPoint

### DIFF
--- a/datastreams/payload.go
+++ b/datastreams/payload.go
@@ -33,6 +33,13 @@ type StatsBucket struct {
 	Stats []StatsPoint
 }
 
+type TimestampType string
+
+const (
+	TIMESTAMP_TYPE_CURRENT TimestampType = "current"
+	TIMESTAMP_TYPE_ORIGIN  TimestampType = "origin"
+)
+
 // StatsPoint contains a set of statistics grouped under various aggregation keys.
 type StatsPoint struct {
 	// These fields indicate the properties under which the stats were aggregated.
@@ -44,4 +51,5 @@ type StatsPoint struct {
 	// those are distributions of latency in seconds.
 	PathwayLatency []byte
 	EdgeLatency    []byte
+	TimestampType  TimestampType
 }

--- a/datastreams/payload_msgp.go
+++ b/datastreams/payload_msgp.go
@@ -346,6 +346,16 @@ func (z *StatsPoint) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "EdgeLatency")
 				return
 			}
+		case "TimestampType":
+			{
+				var zb0003 string
+				zb0003, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "TimestampType")
+					return
+				}
+				z.TimestampType = TimestampType(zb0003)
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -359,9 +369,9 @@ func (z *StatsPoint) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *StatsPoint) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 6
+	// map header, size 7
 	// write "Service"
-	err = en.Append(0x86, 0xa7, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65)
+	err = en.Append(0x87, 0xa7, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65)
 	if err != nil {
 		return
 	}
@@ -427,6 +437,16 @@ func (z *StatsPoint) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "EdgeLatency")
 		return
 	}
+	// write "TimestampType"
+	err = en.Append(0xad, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x54, 0x79, 0x70, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(string(z.TimestampType))
+	if err != nil {
+		err = msgp.WrapError(err, "TimestampType")
+		return
+	}
 	return
 }
 
@@ -436,6 +456,36 @@ func (z *StatsPoint) Msgsize() (s int) {
 	for za0001 := range z.EdgeTags {
 		s += msgp.StringPrefixSize + len(z.EdgeTags[za0001])
 	}
-	s += 5 + msgp.Uint64Size + 11 + msgp.Uint64Size + 15 + msgp.BytesPrefixSize + len(z.PathwayLatency) + 12 + msgp.BytesPrefixSize + len(z.EdgeLatency)
+	s += 5 + msgp.Uint64Size + 11 + msgp.Uint64Size + 15 + msgp.BytesPrefixSize + len(z.PathwayLatency) + 12 + msgp.BytesPrefixSize + len(z.EdgeLatency) + 14 + msgp.StringPrefixSize + len(string(z.TimestampType))
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TimestampType) DecodeMsg(dc *msgp.Reader) (err error) {
+	{
+		var zb0001 string
+		zb0001, err = dc.ReadString()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		(*z) = TimestampType(zb0001)
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z TimestampType) EncodeMsg(en *msgp.Writer) (err error) {
+	err = en.WriteString(string(z))
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z TimestampType) Msgsize() (s int) {
+	s = msgp.StringPrefixSize + len(string(z))
 	return
 }


### PR DESCRIPTION
Add a new timestampType field to StatsPoint, allowing us to send points with timestamps that are either based on current time or origin time. To be used in new availability metric to help us quickly detect offline consumers.