### PR TITLE
Add partition edge tags for Kafka integration on both producer and consumer side

### DIFF
--- a/datastreams/aggregator_test.go
+++ b/datastreams/aggregator_test.go
@@ -33,7 +33,7 @@ func TestAggregator(t *testing.T) {
 	tp2 := time.Unix(0, alignTs(tp1.Add(time.Second*40).UnixNano(), bucketDuration.Nanoseconds())).Add(6 * time.Second)
 
 	p.add(statsPoint{
-		edgeTags:       []string{"edge-1"},
+		edgeTags:       []string{"type:edge-1"},
 		hash:           2,
 		parentHash:     1,
 		timestamp:      tp2.UnixNano(),
@@ -41,7 +41,7 @@ func TestAggregator(t *testing.T) {
 		edgeLatency:    time.Second.Nanoseconds(),
 	})
 	p.add(statsPoint{
-		edgeTags:       []string{"edge-1"},
+		edgeTags:       []string{"type:edge-1"},
 		hash:           2,
 		parentHash:     1,
 		timestamp:      tp2.UnixNano(),
@@ -49,7 +49,7 @@ func TestAggregator(t *testing.T) {
 		edgeLatency:    (2 * time.Second).Nanoseconds(),
 	})
 	p.add(statsPoint{
-		edgeTags:       []string{"edge-1"},
+		edgeTags:       []string{"type:edge-1"},
 		hash:           3,
 		parentHash:     1,
 		timestamp:      tp2.UnixNano(),
@@ -57,7 +57,7 @@ func TestAggregator(t *testing.T) {
 		edgeLatency:    (2 * time.Second).Nanoseconds(),
 	})
 	p.add(statsPoint{
-		edgeTags:       []string{"edge-1"},
+		edgeTags:       []string{"type:edge-1"},
 		hash:           2,
 		parentHash:     1,
 		timestamp:      tp1.UnixNano(),
@@ -74,7 +74,7 @@ func TestAggregator(t *testing.T) {
 				Start:    uint64(alignTs(tp1.UnixNano(), bucketDuration.Nanoseconds())),
 				Duration: uint64(bucketDuration.Nanoseconds()),
 				Stats: []StatsPoint{{
-					EdgeTags:       []string{"edge-1"},
+					EdgeTags:       []string{"type:edge-1"},
 					Hash:           2,
 					ParentHash:     1,
 					PathwayLatency: buildSketch(5),
@@ -86,7 +86,7 @@ func TestAggregator(t *testing.T) {
 				Start:    uint64(alignTs(tp1.UnixNano()-(5*time.Second).Nanoseconds(), bucketDuration.Nanoseconds())),
 				Duration: uint64(bucketDuration.Nanoseconds()),
 				Stats: []StatsPoint{{
-					EdgeTags:       []string{"edge-1"},
+					EdgeTags:       []string{"type:edge-1"},
 					Hash:           2,
 					ParentHash:     1,
 					PathwayLatency: buildSketch(5),
@@ -95,7 +95,7 @@ func TestAggregator(t *testing.T) {
 				}},
 			},
 		},
-		TracerVersion: "v0.2",
+		TracerVersion: "v0.3",
 		Lang:          "go",
 	}, p.flush(tp2))
 
@@ -113,7 +113,7 @@ func TestAggregator(t *testing.T) {
 				Duration: uint64(bucketDuration.Nanoseconds()),
 				Stats: []StatsPoint{
 					{
-						EdgeTags:       []string{"edge-1"},
+						EdgeTags:       []string{"type:edge-1"},
 						Hash:           2,
 						ParentHash:     1,
 						PathwayLatency: buildSketch(1, 5),
@@ -121,7 +121,7 @@ func TestAggregator(t *testing.T) {
 						TimestampType:  "current",
 					},
 					{
-						EdgeTags:       []string{"edge-1"},
+						EdgeTags:       []string{"type:edge-1"},
 						Hash:           3,
 						ParentHash:     1,
 						PathwayLatency: buildSketch(5),
@@ -135,7 +135,7 @@ func TestAggregator(t *testing.T) {
 				Duration: uint64(bucketDuration.Nanoseconds()),
 				Stats: []StatsPoint{
 					{
-						EdgeTags:       []string{"edge-1"},
+						EdgeTags:       []string{"type:edge-1"},
 						Hash:           2,
 						ParentHash:     1,
 						PathwayLatency: buildSketch(1, 5),
@@ -143,7 +143,7 @@ func TestAggregator(t *testing.T) {
 						TimestampType:  "origin",
 					},
 					{
-						EdgeTags:       []string{"edge-1"},
+						EdgeTags:       []string{"type:edge-1"},
 						Hash:           3,
 						ParentHash:     1,
 						PathwayLatency: buildSketch(5),
@@ -153,7 +153,7 @@ func TestAggregator(t *testing.T) {
 				},
 			},
 		},
-		TracerVersion: "v0.2",
+		TracerVersion: "v0.3",
 		Lang:          "go",
 	}, sp)
 }

--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -10,9 +10,12 @@ import (
 	"hash/fnv"
 	"math/rand"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 )
+
+var hashableEdgeTags = map[string]struct{}{"event_type": {}, "exchange": {}, "group": {}, "topic": {}, "type": {}}
 
 // Pathway is used to monitor how payloads are sent across different services.
 // An example Pathway would be:
@@ -54,7 +57,13 @@ func nodeHash(service, env, primaryTag string, edgeTags []string) uint64 {
 	b = append(b, env...)
 	b = append(b, primaryTag...)
 	for _, t := range edgeTags {
-		b = append(b, t...)
+		s := strings.Split(t, ":")
+		if len(s) == 2 {
+			if _, ok := hashableEdgeTags[s[0]]; !ok {
+				continue
+			}
+			b = append(b, t...)
+		}
 	}
 	h := fnv.New64()
 	h.Write(b)

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -95,4 +95,31 @@ func TestPathway(t *testing.T) {
 		assert.Equal(t, hash3, statsPointWith2EdgeTags.hash)
 		assert.Equal(t, []string{"some_other_key:some_other_val", "type:internal"}, statsPointWith2EdgeTags.edgeTags)
 	})
+
+	t.Run("test nodeHash", func(t *testing.T) {
+		assert.NotEqual(t,
+			nodeHash("service-1", "env", "d:1", []string{"type:internal"}),
+			nodeHash("service-1", "env", "d:1", []string{"type:kafka"}),
+		)
+		assert.NotEqual(t,
+			nodeHash("service-1", "env", "d:1", []string{"exchange:1"}),
+			nodeHash("service-1", "env", "d:1", []string{"exchange:2"}),
+		)
+		assert.NotEqual(t,
+			nodeHash("service-1", "env", "d:1", []string{"topic:1"}),
+			nodeHash("service-1", "env", "d:1", []string{"topic:2"}),
+		)
+		assert.NotEqual(t,
+			nodeHash("service-1", "env", "d:1", []string{"group:1"}),
+			nodeHash("service-1", "env", "d:1", []string{"group:2"}),
+		)
+		assert.NotEqual(t,
+			nodeHash("service-1", "env", "d:1", []string{"event_type:1"}),
+			nodeHash("service-1", "env", "d:1", []string{"event_type:2"}),
+		)
+		assert.Equal(t,
+			nodeHash("service-1", "env", "d:1", []string{"partition:0"}),
+			nodeHash("service-1", "env", "d:1", []string{"partition:1"}),
+		)
+	})
 }

--- a/datastreams/version/version.go
+++ b/datastreams/version/version.go
@@ -8,4 +8,4 @@ package version
 // Tag specifies the current release tag. It needs to be manually
 // updated. A test checks that the value of Tag never points to a
 // git tag that is older than HEAD.
-const Tag = "v0.2"
+const Tag = "v0.3"

--- a/integrations/kafka/consumer.go
+++ b/integrations/kafka/consumer.go
@@ -7,6 +7,7 @@ package kafka
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 
@@ -22,6 +23,7 @@ func TraceKafkaConsume(ctx context.Context, msg *kafka.Message, group string) co
 	if msg.TopicPartition.Topic != nil {
 		edges = append(edges, "topic:"+*msg.TopicPartition.Topic)
 	}
+	edges = append(edges, "partition:"+strconv.Itoa(int(msg.TopicPartition.Partition)))
 	_, ctx = datastreams.SetCheckpoint(ctx, edges...)
 	return ctx
 }

--- a/integrations/kafka/producer.go
+++ b/integrations/kafka/producer.go
@@ -7,6 +7,7 @@ package kafka
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 
@@ -17,7 +18,14 @@ import (
 // newly updated context which records the updated pathway. Do not pass the resulting context from
 // this function to another call of TraceKafkaProduce, as it will modify the pathway incorrectly.
 func TraceKafkaProduce(ctx context.Context, msg *kafka.Message) context.Context {
-	p, ctx := datastreams.SetCheckpoint(ctx, "type:internal")
+	edges := []string{"type:internal"}
+	if msg.TopicPartition.Topic != nil {
+		edges = append(edges, "topic:"+*msg.TopicPartition.Topic)
+	}
+	if msg.TopicPartition.Partition != kafka.PartitionAny {
+		edges = append(edges, "partition:"+strconv.Itoa(int(msg.TopicPartition.Partition)))
+	}
+	p, ctx := datastreams.SetCheckpoint(ctx, edges...)
 	msg.Headers = append(msg.Headers, kafka.Header{Key: datastreams.PropagationKey, Value: p.Encode()})
 	return ctx
 }


### PR DESCRIPTION
- When adding checkpoints at Kafka producer and consumer calls, also send along `partition` as an edge tag.
- On Kafka producer side, if the partition is `kafka.PartitionAny`, the partitioner would be used to send keys to the correct partition and we won't know at this point which partition we're producing to, so we won't add the `partition` tag in that case.
- This PR also updates version.go to `0.3`, since `0.2` was released a few days ago.