### PR TITLE
Optimize nodeHash

### DIFF
--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -46,6 +46,17 @@ func Merge(pathways []Pathway) Pathway {
 	return pathways[n]
 }
 
+func isWellFormedEdgeTag(t string) bool {
+	if i := strings.IndexByte(t, ':'); i != -1 {
+		if j := strings.LastIndexByte(t, ':'); j == i {
+			if _, exists := hashableEdgeTags[t[:i]]; exists {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func nodeHash(service, env, primaryTag string, edgeTags []string) uint64 {
 	n := len(service) + len(env) + len(primaryTag)
 	sort.Strings(edgeTags)
@@ -57,11 +68,7 @@ func nodeHash(service, env, primaryTag string, edgeTags []string) uint64 {
 	b = append(b, env...)
 	b = append(b, primaryTag...)
 	for _, t := range edgeTags {
-		s := strings.Split(t, ":")
-		if len(s) == 2 {
-			if _, ok := hashableEdgeTags[s[0]]; !ok {
-				continue
-			}
+		if isWellFormedEdgeTag(t) {
 			b = append(b, t...)
 		}
 	}

--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -58,22 +58,16 @@ func isWellFormedEdgeTag(t string) bool {
 }
 
 func nodeHash(service, env, primaryTag string, edgeTags []string) uint64 {
-	n := len(service) + len(env) + len(primaryTag)
+	h := fnv.New64()
 	sort.Strings(edgeTags)
-	for _, t := range edgeTags {
-		n += len(t)
-	}
-	b := make([]byte, 0, n)
-	b = append(b, service...)
-	b = append(b, env...)
-	b = append(b, primaryTag...)
+	h.Write([]byte(service))
+	h.Write([]byte(env))
+	h.Write([]byte(primaryTag))
 	for _, t := range edgeTags {
 		if isWellFormedEdgeTag(t) {
-			b = append(b, t...)
+			h.Write([]byte(t))
 		}
 	}
-	h := fnv.New64()
-	h.Write(b)
 	return h.Sum64()
 }
 

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -149,7 +149,7 @@ func TestPathway(t *testing.T) {
 // goarch: amd64
 // pkg: github.com/DataDog/data-streams-go/datastreams
 // cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
-// BenchmarkNodeHash-8   	 7118852	       180.2 ns/op	     120 B/op	       2 allocs/op
+// BenchmarkNodeHash-8   	 5167707	       232.5 ns/op	      24 B/op	       1 allocs/op
 func BenchmarkNodeHash(b *testing.B) {
 	service := "benchmark-runner"
 	env := "test"

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -6,6 +6,7 @@
 package datastreams
 
 import (
+	"hash/fnv"
 	"testing"
 	"time"
 
@@ -141,6 +142,24 @@ func TestPathway(t *testing.T) {
 		} {
 			assert.Equal(t, isWellFormedEdgeTag(tc.s), tc.b)
 		}
+	})
+
+	// nodeHash assumes that the go Hash interface produces the same result
+	// for a given series of Write calls as for a single Write of the same
+	// byte sequence. This unit test asserts that assumption.
+	t.Run("test hashWriterIsomorphism", func(t *testing.T) {
+		h := fnv.New64()
+		var b []byte
+		b = append(b, "dog"...)
+		b = append(b, "cat"...)
+		b = append(b, "pig"...)
+		h.Write(b)
+		s1 := h.Sum64()
+		h.Reset()
+		h.Write([]byte("dog"))
+		h.Write([]byte("cat"))
+		h.Write([]byte("pig"))
+		assert.Equal(t, s1, h.Sum64())
 	})
 }
 

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -122,4 +122,40 @@ func TestPathway(t *testing.T) {
 			nodeHash("service-1", "env", "d:1", []string{"partition:1"}),
 		)
 	})
+
+	t.Run("test isWellFormedEdgeTag", func(t *testing.T) {
+		for _, tc := range []struct {
+			s string
+			b bool
+		}{
+			{"", false},
+			{"dog", false},
+			{"dog:", false},
+			{"dog:bark", false},
+			{"type:", true},
+			{"type:dog", true},
+			{"type::dog", false},
+			{"type:d:o:g", false},
+			{"type::", false},
+			{":", false},
+		} {
+			assert.Equal(t, isWellFormedEdgeTag(tc.s), tc.b)
+		}
+	})
+}
+
+// Sample results at time of writing this benchmark:
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/DataDog/data-streams-go/datastreams
+// cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
+// BenchmarkNodeHash-8   	 7118852	       180.2 ns/op	     120 B/op	       2 allocs/op
+func BenchmarkNodeHash(b *testing.B) {
+	service := "benchmark-runner"
+	env := "test"
+	primaryTag := "foo:bar"
+	edgeTags := []string{"event_type:dog", "exchange:local", "group:all", "topic:off", "type:writer"}
+	for i := 0; i < b.N; i++ {
+		nodeHash(service, env, primaryTag, edgeTags)
+	}
 }


### PR DESCRIPTION
nodeHash is responsible for 5% of the allocations in APM trace-fetcher, and I suspect that is true of other kafka consumers as well. A refactor of nodeHash avoids all but one allocation on the hot path. The added microbenchmark indicates this is also about 50% faster.