### PR TITLE
Add Pathway.GetHash method

### DIFF
--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -94,6 +94,11 @@ func newPathway(now time.Time, edgeTags ...string) Pathway {
 	return p.setCheckpoint(now, edgeTags)
 }
 
+// GetHash gets the hash of a pathway.
+func (p Pathway) GetHash() uint64 {
+	return p.hash
+}
+
 // SetCheckpoint sets a checkpoint on a pathway.
 func (p Pathway) SetCheckpoint(edgeTags ...string) Pathway {
 	return p.setCheckpoint(time.Now(), edgeTags)

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPathway(t *testing.T) {
-	t.Run("test SetCheckPoint", func(t *testing.T) {
+	t.Run("test SetCheckpoint", func(t *testing.T) {
 		aggregator := aggregator{
 			stopped:    1,
 			in:         make(chan statsPoint, 10),
@@ -160,6 +160,11 @@ func TestPathway(t *testing.T) {
 		h.Write([]byte("cat"))
 		h.Write([]byte("pig"))
 		assert.Equal(t, s1, h.Sum64())
+	})
+
+	t.Run("test GetHash", func(t *testing.T) {
+		pathway := NewPathway("type:kafka", "topic:my-topic", "direction:in")
+		assert.Equal(t, pathway.hash, pathway.GetHash())
 	})
 }
 


### PR DESCRIPTION
This PR adds a new method named `GetHash` to `Pathway`. This will allow users to get the hash of a pathway, and then add it to a span as a tag.