### PR TITLE
Add ability to trigger a flush

### DIFF
--- a/datastreams/aggregator.go
+++ b/datastreams/aggregator.go
@@ -148,6 +148,7 @@ type aggregator struct {
 	wg                   sync.WaitGroup
 	stopped              uint64
 	stop                 chan struct{} // closing this channel triggers shutdown
+	flushRequest         chan chan<- struct{}
 	stats                aggregatorStats
 	transport            *httpTransport
 	statsd               statsd.ClientInterface
@@ -239,6 +240,9 @@ func (a *aggregator) run(tick <-chan time.Time) {
 			a.addKafkaOffset(o)
 		case now := <-tick:
 			a.sendToAgent(a.flush(now))
+		case done := <-a.flushRequest:
+			a.sendToAgent(a.flush(time.Now().Add(bucketDuration * 10)))
+			done <- struct{}{}
 		case <-a.stop:
 			// drop in flight payloads on the input channel
 			a.sendToAgent(a.flush(time.Now().Add(bucketDuration * 10)))
@@ -254,6 +258,7 @@ func (a *aggregator) Start() {
 		return
 	}
 	a.stop = make(chan struct{})
+	a.flushRequest = make(chan chan<- struct{})
 	a.wg.Add(2)
 	go func() {
 		defer a.wg.Done()
@@ -278,6 +283,19 @@ func (a *aggregator) Stop() {
 	a.wg.Wait()
 }
 
+// Flush triggers a flush and waits for it to complete.
+func (a *aggregator) Flush() {
+	if atomic.LoadUint64(&a.stopped) > 0 {
+		return
+	}
+	done := make(chan struct{})
+	select {
+	case a.flushRequest <- done:
+		<-done
+	case <-a.stop:
+	}
+}
+
 func (a *aggregator) runStatsReporter(tick <-chan time.Time) {
 	for {
 		select {
@@ -296,16 +314,6 @@ func (a *aggregator) reportStats() {
 	a.statsd.Count("datadog.datastreams.aggregator.flushed_buckets", atomic.SwapInt64(&a.stats.flushedBuckets, 0), nil, 1)
 	a.statsd.Count("datadog.datastreams.aggregator.flush_errors", atomic.SwapInt64(&a.stats.flushErrors, 0), nil, 1)
 	a.statsd.Count("datadog.datastreams.dropped_payloads", atomic.SwapInt64(&a.stats.dropped, 0), nil, 1)
-}
-
-func (a *aggregator) runFlusher() {
-	for {
-		select {
-		case <-a.stop:
-			// flush everything, so add a few bucketDurations to the current time in order to get a good margin.
-			return
-		}
-	}
 }
 
 func (a *aggregator) flushBucket(buckets map[int64]bucket, bucketStart int64, timestampType TimestampType) StatsBucket {

--- a/datastreams/aggregator.go
+++ b/datastreams/aggregator.go
@@ -242,7 +242,7 @@ func (a *aggregator) run(tick <-chan time.Time) {
 			a.sendToAgent(a.flush(now))
 		case done := <-a.flushRequest:
 			a.sendToAgent(a.flush(time.Now().Add(bucketDuration * 10)))
-			done <- struct{}{}
+			close(done)
 		case <-a.stop:
 			// drop in flight payloads on the input channel
 			a.sendToAgent(a.flush(time.Now().Add(bucketDuration * 10)))

--- a/datastreams/init.go
+++ b/datastreams/init.go
@@ -56,3 +56,10 @@ func Stop() {
 	p.Stop()
 	setGlobalAggregator(nil)
 }
+
+// Flush triggers a flush and waits for it to complete.
+func Flush() {
+	if p := getGlobalAggregator(); p != nil {
+		p.Flush()
+	}
+}


### PR DESCRIPTION
This PR adds the ability to flush buffered stats. It can be used in Lambda functions to flush all stats after each invocation, in a similar way to how the `datadog-lambda-go` library [flushes](https://github.com/DataDog/datadog-lambda-go/blob/7ac44159f354bc9c02f087eb11417f79892fd423/internal/trace/listener.go#L102) all buffered traces.

The implementation is similar to how `Flush` is [implemented](https://github.com/DataDog/dd-trace-go/blob/d95fdb5f0c9fe4a0645612ff71db1602af684a30/ddtrace/tracer/tracer.go#L322-L330) in `dd-trace-go`.