### PR TITLE
Add ability to specify custom HTTP client

### DIFF
--- a/datastreams/options.go
+++ b/datastreams/options.go
@@ -328,3 +328,10 @@ func WithAgentless(apiKey string) StartOption {
 		c.agentLess = true
 	}
 }
+
+// WithHTTPClient specifies the HTTP client to use when communicating with the agent.
+func WithHTTPClient(client *http.Client) StartOption {
+	return func(c *config) {
+		c.httpClient = client
+	}
+}


### PR DESCRIPTION
This PR adds the ability to specify a custom HTTP client. (Note: there is a [similar option ](https://github.com/DataDog/dd-trace-go/blob/30bfd5205d6af7bc8928b90e92310ae35879726b/ddtrace/tracer/option.go#L859-L863) in dd-trace-go.)