### PR TITLE
Address Info Logs to StdErr

### DIFF
--- a/datastreams/options.go
+++ b/datastreams/options.go
@@ -235,7 +235,7 @@ func loadAgentFeatures(client *http.Client, agentAddr string) (features agentFea
 	for _, endpoint := range info.Endpoints {
 		switch endpoint {
 		case "/v0.1/pipeline_stats":
-			c.features.PipelineStats = true
+			features.PipelineStats = true
 			fmt.Println("INFO: Enable pipeline stats.")
 		}
 	}

--- a/datastreams/options.go
+++ b/datastreams/options.go
@@ -132,7 +132,7 @@ func newConfig(opts ...StartOption) *config {
 		c.dogstatsdAddr = addr
 		client, err := statsd.New(addr, statsd.WithMaxMessagesPerPayload(40), statsd.WithTags(statsTags(c)))
 		if err != nil {
-			log.Printf("INFO: Runtime and health metrics disabled: %v", err)
+			log.Printf("ERROR: Runtime and health metrics disabled: %v", err)
 			c.statsd = &statsd.NoOpClient{}
 		} else {
 			c.statsd = client

--- a/datastreams/options.go
+++ b/datastreams/options.go
@@ -245,7 +245,7 @@ func (c *config) loadAgentFeatures() {
 		switch endpoint {
 		case "/v0.1/pipeline_stats":
 			c.features.PipelineStats = true
-			log.Printf("INFO: Enable pipeline stats.")
+			fmt.Println("INFO: Enable pipeline stats.")
 		}
 	}
 }


### PR DESCRIPTION
There is a bit of inconsistency in the logging provided by this library. There is a mixture of using `fmt` and `log`. One message in particular uses `log` which results in output to `stderr` which isn't actually an error:

`INFO: Enable pipeline stats.`

![Screenshot 2023-08-14 at 3 53 17 PM](https://github.com/DataDog/data-streams-go/assets/1462322/b9a76d8b-33df-45ed-9251-2ffab4912d74)

Similarly, the initialization of the statsd library uses `log.Printf` based upon an error for setting up statsd (which some would argue is not an error), to remain consistent I am updating that string as well.

I think the smallest change is to change this to match the other invocations of "INFO" logs to use `fmt.Println`. As I know there are larger efforts to migrate this into https://github.com/dataDog/dd-trace-go, I think that larger optimizations such as allowing the user to provide a logger will be handled as part of that migration.