### PR TITLE
data streams: Re-connect if disconnected from agent

### DIFF
--- a/datastreams/aggregator_test.go
+++ b/datastreams/aggregator_test.go
@@ -29,7 +29,7 @@ func buildSketch(values ...float64) []byte {
 }
 
 func TestAggregator(t *testing.T) {
-	p := newAggregator(nil, "env", "datacenter:us1.prod.dog", "service", "agent-addr", nil, "datadoghq.com", "key", true)
+	p := newAggregator(nil, "env", "datacenter:us1.prod.dog", "service", "agent-addr", nil, "datadoghq.com", "key", true, true)
 	tp1 := time.Now()
 	// Set tp2 to be some 40 seconds after the tp1, but also account for bucket alignments,
 	// otherwise the possible StatsPayload would change depending on when the test is run.
@@ -177,7 +177,7 @@ func TestAggregator(t *testing.T) {
 }
 
 func TestKafkaLag(t *testing.T) {
-	a := newAggregator(nil, "env", "datacenter:us1.prod.dog", "service", "agent-addr", nil, "datadoghq.com", "key", true)
+	a := newAggregator(nil, "env", "datacenter:us1.prod.dog", "service", "agent-addr", nil, "datadoghq.com", "key", true, true)
 	tp1 := time.Now()
 	a.addKafkaOffset(kafkaOffset{offset: 1, topic: "topic1", partition: 1, group: "group1", offsetType: commitOffset})
 	a.addKafkaOffset(kafkaOffset{offset: 10, topic: "topic2", partition: 1, group: "group1", offsetType: commitOffset})

--- a/datastreams/init.go
+++ b/datastreams/init.go
@@ -37,11 +37,11 @@ func getGlobalAggregator() *aggregator {
 // Start starts the data streams stats aggregator that will record pipeline stats and send them to the agent.
 func Start(opts ...StartOption) {
 	cfg := newConfig(opts...)
-	if !cfg.agentLess && !cfg.features.PipelineStats {
-		log.Print("ERROR: Agent does not support pipeline stats and pipeline stats aggregator launched in agent mode.")
-		return
+	supportDataStreamsStats := cfg.agentLess || cfg.features.PipelineStats
+	if !supportDataStreamsStats {
+		log.Print("WARNING: Agent does not support pipeline stats and pipeline stats aggregator launched in agent mode.")
 	}
-	p := newAggregator(cfg.statsd, cfg.env, cfg.primaryTag, cfg.service, cfg.agentAddr, cfg.httpClient, cfg.site, cfg.apiKey, cfg.agentLess)
+	p := newAggregator(cfg.statsd, cfg.env, cfg.primaryTag, cfg.service, cfg.agentAddr, cfg.httpClient, cfg.site, cfg.apiKey, cfg.agentLess, supportDataStreamsStats)
 	p.Start()
 	setGlobalAggregator(p)
 }


### PR DESCRIPTION
If the datadog agent is upgraded while the application runs, or if the agent is not available at startup, ensure the tracer starts flushing traces to it when possible.