### PR TITLE
[data streams] Improve performance for high throughput applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+FlameGraph/
+cpu.prof
+*.svg

--- a/datastreams/aggregator_test.go
+++ b/datastreams/aggregator_test.go
@@ -7,6 +7,7 @@ package datastreams
 
 import (
 	"context"
+	"encoding/binary"
 	"github.com/DataDog/data-streams-go/datastreams/version"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"net/http"
@@ -234,4 +235,12 @@ func BenchmarkSetCheckpoint(b *testing.B) {
 		SetCheckpointWithParams(context.Background(), CheckpointParams{PayloadSize: 1000}, "type:edge-1", "direction:in", "type:kafka", "topic:topic1", "group:group1")
 	}
 	p.Stop()
+}
+
+func TestGetHashKey(t *testing.T) {
+	parentHash := uint64(87234)
+	key := getHashKey([]string{"type:kafka", "topic:topic1", "group:group1"}, parentHash)
+	hash := make([]byte, 8)
+	binary.LittleEndian.PutUint64(hash, parentHash)
+	assert.Equal(t, "type:kafkatopic:topic1group:group1"+string(hash), key)
 }

--- a/datastreams/aggregator_test.go
+++ b/datastreams/aggregator_test.go
@@ -38,7 +38,7 @@ func TestAggregator(t *testing.T) {
 	// otherwise the possible StatsPayload would change depending on when the test is run.
 	tp2 := time.Unix(0, alignTs(tp1.Add(time.Second*40).UnixNano(), bucketDuration.Nanoseconds())).Add(6 * time.Second)
 
-	p.add(&statsPoint{
+	p.add(statsPoint{
 		edgeTags:       []string{"type:edge-1"},
 		hash:           2,
 		parentHash:     1,
@@ -47,7 +47,7 @@ func TestAggregator(t *testing.T) {
 		edgeLatency:    time.Second.Nanoseconds(),
 		payloadSize:    1,
 	})
-	p.add(&statsPoint{
+	p.add(statsPoint{
 		edgeTags:       []string{"type:edge-1"},
 		hash:           2,
 		parentHash:     1,
@@ -56,7 +56,7 @@ func TestAggregator(t *testing.T) {
 		edgeLatency:    (2 * time.Second).Nanoseconds(),
 		payloadSize:    2,
 	})
-	p.add(&statsPoint{
+	p.add(statsPoint{
 		edgeTags:       []string{"type:edge-1"},
 		hash:           3,
 		parentHash:     1,
@@ -65,7 +65,7 @@ func TestAggregator(t *testing.T) {
 		edgeLatency:    (2 * time.Second).Nanoseconds(),
 		payloadSize:    2,
 	})
-	p.add(&statsPoint{
+	p.add(statsPoint{
 		edgeTags:       []string{"type:edge-1"},
 		hash:           2,
 		parentHash:     1,

--- a/datastreams/context_test.go
+++ b/datastreams/context_test.go
@@ -30,8 +30,8 @@ func TestContext(t *testing.T) {
 		pathway, ctx := SetCheckpoint(ctx, "type:internal")
 		pathway, _ = SetCheckpoint(ctx, "type:kafka")
 
-		statsPt1 := aggregator.in.pop()
-		statsPt2 := aggregator.in.pop()
+		statsPt1 := aggregator.in.pop().point
+		statsPt2 := aggregator.in.pop().point
 
 		assert.Equal(t, []string{"type:internal"}, statsPt1.edgeTags)
 		assert.Equal(t, hash1, statsPt1.hash)

--- a/datastreams/context_test.go
+++ b/datastreams/context_test.go
@@ -16,7 +16,7 @@ func TestContext(t *testing.T) {
 	t.Run("SetCheckpoint", func(t *testing.T) {
 		aggregator := aggregator{
 			stopped:    1,
-			in:         make(chan statsPoint, 10),
+			in:         newFastQueue(),
 			service:    "service-1",
 			env:        "env",
 			primaryTag: "d:1",
@@ -30,8 +30,8 @@ func TestContext(t *testing.T) {
 		pathway, ctx := SetCheckpoint(ctx, "type:internal")
 		pathway, _ = SetCheckpoint(ctx, "type:kafka")
 
-		statsPt1 := <-aggregator.in
-		statsPt2 := <-aggregator.in
+		statsPt1 := aggregator.in.pop()
+		statsPt2 := aggregator.in.pop()
 
 		assert.Equal(t, []string{"type:internal"}, statsPt1.edgeTags)
 		assert.Equal(t, hash1, statsPt1.hash)

--- a/datastreams/fast_queue.go
+++ b/datastreams/fast_queue.go
@@ -11,7 +11,7 @@ const (
 // reader will stop if it catches up with writer
 // if reader is too slow, there is no guarantee in which order values will be dropped.
 type fastQueue struct {
-	elements [queueSize]atomic.Pointer[statsPoint]
+	elements [queueSize]atomic.Pointer[aggregatorInput]
 	writePos int64
 	readPos  int64
 }
@@ -20,13 +20,13 @@ func newFastQueue() *fastQueue {
 	return &fastQueue{}
 }
 
-func (q *fastQueue) push(p *statsPoint) {
+func (q *fastQueue) push(p *aggregatorInput) {
 	ind := atomic.AddInt64(&q.writePos, 1)
 	p.queuePos = ind - 1
 	q.elements[(ind-1)%queueSize].Store(p)
 }
 
-func (q *fastQueue) pop() *statsPoint {
+func (q *fastQueue) pop() *aggregatorInput {
 	writePos := atomic.LoadInt64(&q.writePos)
 	if writePos <= q.readPos {
 		return nil

--- a/datastreams/fast_queue.go
+++ b/datastreams/fast_queue.go
@@ -1,0 +1,42 @@
+package datastreams
+
+import "sync/atomic"
+
+const (
+	queueSize = 10000
+)
+
+// there are many writers, there is only 1 reader.
+// each value will be read at most once.
+// reader will stop if it catches up with writer
+// if reader is too slow, there is no guarantee in which order values will be dropped.
+type fastQueue struct {
+	elements [queueSize]atomic.Pointer[statsPoint]
+	writePos int64
+	readPos  int64
+}
+
+func newFastQueue() *fastQueue {
+	return &fastQueue{}
+}
+
+func (q *fastQueue) push(p *statsPoint) {
+	ind := atomic.AddInt64(&q.writePos, 1)
+	p.queuePos = ind - 1
+	q.elements[(ind-1)%queueSize].Store(p)
+}
+
+func (q *fastQueue) pop() *statsPoint {
+	writePos := atomic.LoadInt64(&q.writePos)
+	if writePos <= q.readPos {
+		return nil
+	}
+	loaded := q.elements[q.readPos%queueSize].Load()
+	if loaded == nil || loaded.queuePos < q.readPos {
+		// the write started, but hasn't finished yet, the element we read
+		// is the one from the previous cycle.
+		return nil
+	}
+	q.readPos++
+	return loaded
+}

--- a/datastreams/kafka.go
+++ b/datastreams/kafka.go
@@ -1,39 +1,30 @@
 package datastreams
 
 import (
-	"sync/atomic"
 	"time"
 )
 
 func TrackKafkaCommitOffset(group string, topic string, partition int32, offset int64) {
 	if aggregator := getGlobalAggregator(); aggregator != nil {
-		select {
-		case aggregator.inKafka <- kafkaOffset{
+		aggregator.in.push(&aggregatorInput{kafkaOffset: kafkaOffset{
 			offset:     offset,
 			group:      group,
 			topic:      topic,
 			partition:  partition,
 			offsetType: commitOffset,
 			timestamp:  time.Now().UnixNano(),
-		}:
-		default:
-			atomic.AddInt64(&aggregator.stats.dropped, 1)
-		}
+		}})
 	}
 }
 
 func TrackKafkaProduce(topic string, partition int32, offset int64) {
 	if aggregator := getGlobalAggregator(); aggregator != nil {
-		select {
-		case aggregator.inKafka <- kafkaOffset{
+		aggregator.in.push(&aggregatorInput{kafkaOffset: kafkaOffset{
 			offset:     offset,
 			topic:      topic,
 			partition:  partition,
 			offsetType: produceOffset,
 			timestamp:  time.Now().UnixNano(),
-		}:
-		default:
-			atomic.AddInt64(&aggregator.stats.dropped, 1)
-		}
+		}})
 	}
 }

--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -129,7 +129,7 @@ func (p Pathway) setCheckpoint(now time.Time, params CheckpointParams, edgeTags 
 		edgeStart:    now,
 	}
 	if aggr != nil {
-		aggr.in.push(&statsPoint{
+		aggr.in.push(&aggregatorInput{point: statsPoint{
 			edgeTags:       edgeTags,
 			parentHash:     p.hash,
 			hash:           child.hash,
@@ -137,7 +137,7 @@ func (p Pathway) setCheckpoint(now time.Time, params CheckpointParams, edgeTags 
 			pathwayLatency: now.Sub(p.pathwayStart).Nanoseconds(),
 			edgeLatency:    now.Sub(p.edgeStart).Nanoseconds(),
 			payloadSize:    params.PayloadSize,
-		})
+		}})
 	}
 	return child
 }

--- a/datastreams/pathway.go
+++ b/datastreams/pathway.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"sort"
 	"strings"
-	"sync/atomic"
 	"time"
 )
 
@@ -117,19 +116,20 @@ func (p Pathway) setCheckpoint(now time.Time, params CheckpointParams, edgeTags 
 	service := defaultServiceName
 	primaryTag := ""
 	env := ""
+	var hash uint64
 	if aggr != nil {
 		service = aggr.service
 		primaryTag = aggr.primaryTag
 		env = aggr.env
+		hash = aggr.hashCache.get(service, env, primaryTag, edgeTags, p.hash)
 	}
 	child := Pathway{
-		hash:         pathwayHash(nodeHash(service, env, primaryTag, edgeTags), p.hash),
+		hash:         hash,
 		pathwayStart: p.pathwayStart,
 		edgeStart:    now,
 	}
-	if aggregator := getGlobalAggregator(); aggregator != nil {
-		select {
-		case aggregator.in <- statsPoint{
+	if aggr != nil {
+		aggr.in.push(&statsPoint{
 			edgeTags:       edgeTags,
 			parentHash:     p.hash,
 			hash:           child.hash,
@@ -137,10 +137,7 @@ func (p Pathway) setCheckpoint(now time.Time, params CheckpointParams, edgeTags 
 			pathwayLatency: now.Sub(p.pathwayStart).Nanoseconds(),
 			edgeLatency:    now.Sub(p.edgeStart).Nanoseconds(),
 			payloadSize:    params.PayloadSize,
-		}:
-		default:
-			atomic.AddInt64(&aggregator.stats.dropped, 1)
-		}
+		})
 	}
 	return child
 }

--- a/datastreams/pathway_test.go
+++ b/datastreams/pathway_test.go
@@ -86,9 +86,9 @@ func TestPathway(t *testing.T) {
 		assert.Equal(t, hash2, pathwayWith1EdgeTag.hash)
 		assert.Equal(t, hash3, pathwayWith2EdgeTags.hash)
 
-		var statsPointWithNoEdgeTags statsPoint = *aggregator.in.pop()
-		var statsPointWith1EdgeTag statsPoint = *aggregator.in.pop()
-		var statsPointWith2EdgeTags statsPoint = *aggregator.in.pop()
+		var statsPointWithNoEdgeTags statsPoint = aggregator.in.pop().point
+		var statsPointWith1EdgeTag statsPoint = aggregator.in.pop().point
+		var statsPointWith2EdgeTags statsPoint = aggregator.in.pop().point
 		assert.Equal(t, hash1, statsPointWithNoEdgeTags.hash)
 		assert.Equal(t, []string(nil), statsPointWithNoEdgeTags.edgeTags)
 		assert.Equal(t, hash2, statsPointWith1EdgeTag.hash)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/data-streams-go
 
-go 1.17
+go 1.18
 
 replace github.com/DataDog/data-streams-go/integrations/kafka => ./integrations/kafka
 


### PR DESCRIPTION
- Add cache for computing hashes
- Remove channels on the fast path
- Use stringBuilder to build strings.